### PR TITLE
feat: add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+scripts/* text eol=lf
+bin/stf text eol=lf


### PR DESCRIPTION
This change aims to prevent errors like: "env: node\r: No such file or directory" related to incorrect CRLF line endings when running docker-compose after checkout. 