### PR TITLE
fix(db): add null-check in setLockOnUser to prevent missing groups error

### DIFF
--- a/lib/db/api.js
+++ b/lib/db/api.js
@@ -690,26 +690,30 @@ export const setLockOnDevices = function(serials, lock) {
  */
 function setLockOnUser(email, state) {
     return db.connect().then(client => {
-        return client.collection('users').findOne({email: email}).then(oldDoc => {
-            return client.collection('users').updateOne({
-                email: email
+        return client.collection('users').findOne({ email: email }).then(oldDoc => {
+            if (!oldDoc || !oldDoc.groups) {
+                throw new Error(`User with email ${email} not found or groups field is missing.`);
             }
-            ,
-            {
-                $set: {'groups.lock': oldDoc.groups.lock !== state ? state : oldDoc.groups.lock}
-            }
+            return client.collection('users').updateOne(
+                { email: email },
+                {
+                    $set: {
+                        'groups.lock': oldDoc.groups.lock !== state ? state : oldDoc.groups.lock
+                    }
+                }
             )
-                .then(updateStats => {
-                    return client.collection('users').findOne({email: email}).then(newDoc => {
-                        updateStats.changes = [
-                            {new_val: {...newDoc}, old_val: {...oldDoc}}
-                        ]
-                        return updateStats
-                    })
-                })
-        })
-    })
+            .then(updateStats => {
+                return client.collection('users').findOne({ email: email }).then(newDoc => {
+                    updateStats.changes = [
+                        { new_val: { ...newDoc }, old_val: { ...oldDoc } }
+                    ];
+                    return updateStats;
+                });
+            });
+        });
+    });
 }
+
 
 // dbapi.lockUser = function(email) {
 export const lockUser = function(email) {


### PR DESCRIPTION
 **Overview**
 
 This PR updates the `setLockOnUser` function in `lib/db/api.js`. Previously, the function assumed that every user document always had a `groups` field. In cases where a user was deleted or misconfigured (e.g. missing the `groups` field), the function would throw a cryptic error ("Cannot read properties of null (reading 'groups')"). With this update, we now explicitly check for the existence of the user document and its `groups` field before proceeding.
 
 **Changes**
 
 - Added a null-check immediately after fetching the user document. If the document or its `groups` field is missing, the function now throws an error with the message:
   ```
   User with email ${email} not found or groups field is missing.
   ```
 - The rest of the function remains unchanged, ensuring that if the document is valid, it continues to update the `groups.lock` field as before.
 
 
 **Impact**
 
 While this change does not prevent devicehub-api from crashing if a misconfigured user is encountered, it improves ability to troubleshoot the issue by providing a descriptive error message. Further enhancements may be considered in the future to handle such errors more gracefully.
