### PR TITLE
Update docker-compose-prod.yaml

### DIFF
--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -63,6 +63,7 @@ services:
             start_period: 0s
             start_interval: 1s
             retries: 30
+        restart: unless-stopped
         networks:
             devicehub:
         volumes:


### PR DESCRIPTION
 **Overview**
 
 This PR updates the production Docker Compose configuration by adding the restart policy "unless-stopped" for the devicehub-mongo service in `docker-compose-prod.yaml`.
 
 **Changes**
 
 - In the `devicehub-mongo` service, the following line has been added:
 
   ```yaml
   restart: unless-stopped
   ```
 
 **Reasoning**
 
 Adding the restart policy "unless-stopped" ensures that the MongoDB container automatically recovers after system reboots, thus enhancing the resilience and availability of our application services.
 
 **Testing**
 
 The changes have been tested locally. After a system reboot, the container correctly restarts without manual intervention.
