### PR TITLE
remove strange condition

### DIFF
--- a/lib/units/websocket/index.js
+++ b/lib/units/websocket/index.js
@@ -138,9 +138,7 @@ export default (function(options) {
                 if (user.privilege === 'admin' ||
                 user.email === message.group.owner.email ||
                 !apiutil.isOriginGroup(message.group.class) &&
-                    (message.action === 'deleted' ||
-                        message.action === 'updated' &&
-                            (message.isChangedDates || message.isChangedClass || message.devices.length))) {
+                            (message.isChangedDates || message.isChangedClass || message.devices.length)) {
                     socket.emit('user.settings.groups.' + message.action, message)
                 }
                 if (message.subscribers.indexOf(user.email) > -1) {


### PR DESCRIPTION
This PR remove condition which disable sending on "create" message event.
I decide to remove it because in groups-engine exists code thats always trying to send this event