### PR TITLE
Add test already_used devices

### DIFF
--- a/errorModal.ts
+++ b/errorModal.ts
@@ -1,0 +1,25 @@
+import { expect, Locator, Page } from '@playwright/test'
+import { PageHeader } from '../pageHeader'
+import playwrightConfig from '../../playwright.config'
+
+export class DeviceHubErrorModalPage {
+    readonly page: Page
+    readonly pageHeader: PageHeader
+    readonly baseUrl = playwrightConfig?.use?.baseURL
+    readonly title: Locator
+    readonly description: Locator
+
+    constructor(page: Page, headerText: string, descriptionText: string) {
+        this.page = page
+        this.pageHeader = new PageHeader(this.page)
+        this.title = page.getByText(headerText)
+        this.description = page.getByText(descriptionText)
+
+    }
+
+    async isModalDisplayed() {
+        await expect(this.title).toBeVisible()
+        await expect(this.description).toBeVisible()
+    }
+
+}

--- a/test/e2e/helpers/devicesHelper.ts
+++ b/test/e2e/helpers/devicesHelper.ts
@@ -48,3 +48,20 @@ export async function freeDevice(serial: string) {
     });
     console.log(await devicesResp.json())
 }
+
+export async function useDevice(serial: string, timeout?: number) {
+    const token = await generateAdminToken()
+    const response = await fetch(`${baseUrl}/api/v1/user/devices`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({
+            serial,
+            ...(timeout && { timeout })
+        })
+    })
+
+    console.log(await response.json())
+}

--- a/test/e2e/pageObjects/controlPage/devicePage.ts
+++ b/test/e2e/pageObjects/controlPage/devicePage.ts
@@ -27,4 +27,9 @@ export class DeviceHubDevicePage {
         await this.deviceScreen.isPageDisplayed()
     }
 
+    async isErrorModalDisplayed() {
+        expect(this.page.url()).toBe(`${this.baseUrl}/#/control/${this.deviceSerial}`)
+        
+    }
+
 }

--- a/test/e2e/tests/device.spec.ts
+++ b/test/e2e/tests/device.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from '@playwright/test'
 import {DeviceHubDevicePage} from '../pageObjects/controlPage/devicePage'
-import { freeDevice } from '../helpers/devicesHelper'
+import { freeDevice, useDevice } from '../helpers/devicesHelper'
+import { DeviceHubErrorModalPage } from '../pageObjects/common/errorModal'
+
+const deviceSerial = 'emulator-5554'
 
 test.describe('Device page tests', () => {
-    const deviceSerial = 'emulator-5554'
 
     test.beforeEach('Open main page and use device', async ({ page }) => {
         await new DeviceHubDevicePage(page, deviceSerial).gotoDevice(deviceSerial)
@@ -20,5 +22,16 @@ test.describe('Device page tests', () => {
         await devicePage.deviceScreen.swipeOnDeviceScreen()
         const secondScreen = await devicePage.deviceScreen.getDeviceScreen()
         expect(firstScreen).not.toBe(secondScreen)
+    })
+
+})
+
+test.describe('Device Already used tests', () => {
+    test('Try to use already used device by direct url', async ({ page }) => {
+        await useDevice(deviceSerial)
+        const modalHeader = 'Device was disconnected'
+        const modalDescription = 'Unauthorized'
+        await new DeviceHubDevicePage(page, deviceSerial).gotoDevice(deviceSerial)
+        await new DeviceHubErrorModalPage(page, modalHeader, modalDescription).isModalDisplayed()
     })
 })


### PR DESCRIPTION
1. New Test Case:
   - Name: Device Already Used Tests
   - Objective: Check the system behavior when attempting to access a device that is already in use.
   - Test: Try to use an already used device by direct URL
     - The useDevice function is used to mark the device as in use.
     - DeviceHubDevicePage is initialized to navigate to the device page.
     - The display of the error modal DeviceHubErrorModalPage is checked with the title 'Device was disconnected' and the description 'Unauthorized'.

2. Test Structure:
   - The test first "uses" the device by calling the useDevice function.
   - Attempts to navigate to the device control page via direct URL.
   - Checks if the error modal is displayed when the device is already in use.