### PR TITLE
Fix LDAP groups search

### DIFF
--- a/lib/util/ldaputil.js
+++ b/lib/util/ldaputil.js
@@ -99,20 +99,12 @@ export const login = function(options, username, password) {
                     ]
                 })
 
-                const rootDN = options.search.dn.split(',').reduce((result, part) => {
-                    if (part.toLowerCase().startsWith('dc=')) {
-                        result.push(part)
-                    }
-                    return result
-                }, []).join(',')
-
-                const groupsSearchBase = rootDN || options.search.dn
                 const groupQuery = {
                     scope: 'sub'
                     , filter: groupFilter
                 }
 
-                client.search(groupsSearchBase, groupQuery, function(err, search) {
+                client.search(options.search.dn, groupQuery, function(err, search) {
                     if (err) {
                         resolve([])
                         return


### PR DESCRIPTION
Instead of searching groups by the user's root node (if possible), the search is now always performed from the node specified in the --ldap-search-dn argument.