### PR TITLE
generate jwt instead of tokenID

### DIFF
--- a/lib/db/models/all/model.js
+++ b/lib/db/models/all/model.js
@@ -1259,8 +1259,16 @@ export const loadAccessTokens = function(email) {
 }
 
 // dbapi.loadAccessToken = function(id) {
-export const loadAccessToken = function(id) {
+export const loadAccessTokenById = function(id) {
     return db.collection('accessTokens').findOne({id: id})
+}
+
+export const loadAccessTokenByJwt = function(jwt) {
+    return db.collection('accessTokens').findOne({jwt: jwt})
+}
+
+export const loadAccessTokenByTitle = function(email, title) {
+    return db.collection('accessTokens').findOne({email: email, title: title})
 }
 
 // dbapi.grantAdmin = function(email) {

--- a/lib/units/api/controllers/user.js
+++ b/lib/units/api/controllers/user.js
@@ -13,6 +13,7 @@ import * as apiutil from '../../../util/apiutil.js'
 import * as jwtutil from '../../../util/jwtutil.js'
 import * as lockutil from '../../../util/lockutil.js'
 import * as Sentry from '@sentry/node'
+import generateToken from '../helpers/generateToken.js'
 let log = logger.createLogger('api:controllers:user')
 
 
@@ -530,25 +531,18 @@ function getAccessTokens(req, res) {
 
 function createAccessToken(req, res) {
     const title = req.query.title
-    const jwt = jwtutil.encode({
-        payload: {
-            email: req.user.email
-            , name: req.user.name
-        }
-        , secret: req.options.secret
-    })
-    const id = util.format('%s-%s', uuidv4(), uuidv4()).replace(/-/g, '')
+    const token = generateToken(req.user, req.options.secret)
     dbapi.saveUserAccessToken(req.user.email, {
         title: title
-        , id: id
-        , jwt: jwt
+        , id: token.id
+        , jwt: token.jwt
     })
-        .then(function(token) {
+        .then(function(tokenId) {
             req.options.pushdev.send([
                 req.user.group
                 , wireutil.envelope(new wire.UpdateAccessTokenMessage())
             ])
-            apiutil.respond(res, 201, 'Created (access token)', {token: apiutil.publishAccessToken(token)})
+            apiutil.respond(res, 201, 'Created (access token)', {tokenId: tokenId, token: apiutil.publishAccessToken(token.jwt)})
         })
         .catch(function(err) {
             apiutil.internalError(res, 'Failed to create access token "%s": ', title, err.stack)

--- a/lib/units/api/controllers/user.js
+++ b/lib/units/api/controllers/user.js
@@ -478,21 +478,26 @@ function removeAdbPublicKey(req, res) {
         })
 }
 
-function getAccessToken(req, res) {
+async function getAccessToken(req, res) {
     const id = req.params.id
-    dbapi.loadAccessToken(id).then(function(token) {
+
+    try {
+        let token = await dbapi.loadAccessTokenByJwt(id).catch(() => null)
+        if (!token) {
+            token = await dbapi.loadAccessTokenById(id)
+        }
+
         if (!token || token.email !== req.user.email) {
-            apiutil.respond(res, 404, 'Not Found (access token)')
+            return apiutil.respond(res, 404, 'Not Found (access token)')
         }
-        else {
-            apiutil.respond(res, 200, 'Access Token Information', {
-                token: apiutil.publishAccessToken(token)
-            })
-        }
-    })
-        .catch(function(err) {
-            apiutil.internalError(res, 'Failed to find access token by id "%s": ', id, err.stack)
+
+        apiutil.respond(res, 200, 'Access Token Information', {
+            token: apiutil.publishAccessToken(token)
         })
+    }
+    catch (err) {
+        apiutil.internalError(res, 'Failed to find access token by id "%s": ', id, err.stack)
+    }
 }
 
 export function getAccessTokenByTitle(req, res) {
@@ -570,7 +575,7 @@ function deleteAccessTokens(req, res) {
 
 function deleteAccessToken(req, res) {
     const id = req.params.id
-    dbapi.loadAccessToken(id).then(function(token) {
+    dbapi.loadAccessTokenById(id).then(function(token) {
         if (!token || token.email !== req.user.email) {
             apiutil.respond(res, 404, 'Not Found (access token)')
         }

--- a/lib/units/api/helpers/generateToken.js
+++ b/lib/units/api/helpers/generateToken.js
@@ -1,0 +1,17 @@
+import * as jwtutil from '../../../util/jwtutil.js'
+import util from 'util'
+import {v4 as uuidv4} from 'uuid'
+
+const generateToken = (/** @type {{ email: string; name: string; }} */ user, /** @type {string} */ secret) => {
+    const jwt = jwtutil.encode({
+        payload: {
+            email: user.email
+            , name: user.name
+        }
+        , secret: secret
+    })
+    const id = util.format('%s-%s', uuidv4(), uuidv4()).replace(/-/g, '')
+    return {id: id, jwt: jwt}
+}
+
+export default generateToken

--- a/lib/units/api/helpers/securityHandlers.js
+++ b/lib/units/api/helpers/securityHandlers.js
@@ -50,7 +50,7 @@ async function accessTokenAuth(req, res, next) {
             data = jwtutil.decode(tokenId, req.options.secret)
         }
         catch(e) {
-            const token = await dbapi.loadAccessToken(tokenId)
+            const token = await dbapi.loadAccessTokenById(tokenId)
             if (!token) {
                 throw {
                     status: 401

--- a/lib/units/websocket/index.js
+++ b/lib/units/websocket/index.js
@@ -489,7 +489,7 @@ export default (async function(options) {
                         })
                     socket.emit('user.keys.accessToken.generated', {
                         title: title
-                        , tokenId: token.jwt
+                        , token: token.jwt
                     })
                 })
                 .on('user.keys.accessToken.remove', function(data) {

--- a/lib/units/websocket/index.js
+++ b/lib/units/websocket/index.js
@@ -24,6 +24,7 @@ import * as apiutil from '../../util/apiutil.js'
 import {Server} from 'socket.io'
 import db from '../../db/index.js'
 import EventEmitter from 'events'
+import generateToken from '../api/helpers/generateToken.js'
 const request = Promise.promisifyAll(postmanRequest)
 export default (async function(options) {
     const log = logger.createLogger('websocket')
@@ -477,30 +478,19 @@ export default (async function(options) {
                 .on('user.settings.reset', function() {
                     dbapi.resetUserSettings(user.email)
                 })
-                .on('user.keys.accessToken.generate', function(data) {
-                    var jwt = jwtutil.encode({
-                        payload: {
-                            email: user.email
-                            , name: user.name
-                        }
-                        , secret: options.secret
-                    })
-                    var tokenId = util
-                        .format('%s-%s', uuidv4(), uuidv4())
-                        .replace(/-/g, '')
-                    var {title} = data
-                    return dbapi
+                .on('user.keys.accessToken.generate', async(data) => {
+                    const {title} = data
+                    const token = generateToken(user, options.secret)
+                    await dbapi
                         .saveUserAccessToken(user.email, {
                             title: title
-                            , id: tokenId
-                            , jwt: jwt
+                            , id: token.id
+                            , jwt: token.jwt
                         })
-                        .then(function() {
-                            socket.emit('user.keys.accessToken.generated', {
-                                title: title
-                                , tokenId: tokenId
-                            })
-                        })
+                    socket.emit('user.keys.accessToken.generated', {
+                        title: title
+                        , tokenId: token.jwt
+                    })
                 })
                 .on('user.keys.accessToken.remove', function(data) {
                     const isAdmin = user.privilege === apiutil.ADMIN

--- a/lib/util/apiutil.js
+++ b/lib/util/apiutil.js
@@ -126,8 +126,7 @@ export const publishUser = function(user) {
     return user
 }
 export const publishAccessToken = function(token) {
-    delete token.email
-    delete token.jwt
+    delete token._id
     return token
 }
 export const filterDevice = function(req, device) {

--- a/lib/util/serviceuser.js
+++ b/lib/util/serviceuser.js
@@ -27,7 +27,7 @@ export const generate = async function(email, name, admin, secret) {
             , id: tokenId
             , jwt: jwt
         }).then(() => {
-            userInfo.token = tokenId
+            userInfo.token = jwt
             if (admin) {
                 return dbapi.grantAdmin(email).then(() => {
                     return userInfo

--- a/test/api/test_auth_middleware.py
+++ b/test/api/test_auth_middleware.py
@@ -1,6 +1,5 @@
 from pytest_check import equal
 
-from devicehub_client import AuthenticatedClient
 from devicehub_client.api.admin import create_service_user
 from devicehub_client.api.user import get_access_token
 from devicehub_client.api.users import get_users
@@ -11,10 +10,10 @@ def test_bearer_jwt_token_authentication(api_client, successful_response_check):
     response = get_users.sync_detailed(client=api_client)
     successful_response_check(response, description='Users Information')
 
-def test_bearer_legacy_token_authentication(api_client, successful_response_check, base_url):
+def test_bearer_legacy_token_authentication(api_client, successful_response_check, api_client_custom_token):
     """Test legacy Bearer token authentication"""
     response = get_access_token.sync_detailed(api_client.token, client=api_client)
-    legacy_client = AuthenticatedClient(base_url=base_url, token=response.parsed.additional_properties['id'])
+    legacy_client = api_client_custom_token(response.parsed.token.id)
     response = get_users.sync_detailed(client=legacy_client)
     successful_response_check(response, description='Users Information')
 

--- a/test/api/test_auth_middleware.py
+++ b/test/api/test_auth_middleware.py
@@ -1,15 +1,22 @@
 from pytest_check import equal
 
-from devicehub_client import AuthenticatedClient, Client
+from devicehub_client import AuthenticatedClient
 from devicehub_client.api.admin import create_service_user
+from devicehub_client.api.user import get_access_token
 from devicehub_client.api.users import get_users
 
 
-def test_bearer_token_authentication(api_client, successful_response_check):
+def test_bearer_jwt_token_authentication(api_client, successful_response_check):
     """Test standard Bearer token authentication"""
     response = get_users.sync_detailed(client=api_client)
     successful_response_check(response, description='Users Information')
 
+def test_bearer_legacy_token_authentication(api_client, successful_response_check, base_url):
+    """Test legacy Bearer token authentication"""
+    response = get_access_token.sync_detailed(api_client.token, client=api_client)
+    legacy_client = AuthenticatedClient(base_url=base_url, token=response.parsed.additional_properties['id'])
+    response = get_users.sync_detailed(client=legacy_client)
+    successful_response_check(response, description='Users Information')
 
 def test_invalid_token_authentication(api_client_with_bad_token):
     """Test authentication failure with invalid token"""

--- a/ui/src/components/ui/settings-tabs/keys-tab/access-tokens-control/access-tokens-control.tsx
+++ b/ui/src/components/ui/settings-tabs/keys-tab/access-tokens-control/access-tokens-control.tsx
@@ -63,14 +63,14 @@ export const AccessTokensControl = observer(({ className }: { className?: string
       afterTooltipText={t('Generate Access Token')}
       before={<Icon28KeySquareOutline height={20} width={20} />}
       className={cn(className, styles.accessTokensControl)}
-      isAfterButtonDisabled={!!accessTokenService.generatedTokenId}
+      isAfterButtonDisabled={!!accessTokenService.generatedToken}
       title={t('Access Tokens')}
       separator
       onAfterButtonClick={() => setIsAddNewTokenOpen((prev) => !prev)}
     >
-      <ConditionalRender conditions={[!!accessTokenService.generatedTokenId]}>
+      <ConditionalRender conditions={[!!accessTokenService.generatedToken]}>
         <CopyableBlock
-          copyableText={accessTokenService.generatedTokenId}
+          copyableText={accessTokenService.generatedToken}
           title={t('This is sensitive information. Do not share this token.')}
           onOkClick={() => {
             accessTokenService.resetGeneratedTokenId(accessTokenLabel)
@@ -88,7 +88,7 @@ export const AccessTokensControl = observer(({ className }: { className?: string
               <Input
                 before={<Icon20TagOutline />}
                 className={styles.addNewTokenInput}
-                disabled={!!accessTokenService.generatedTokenId}
+                disabled={!!accessTokenService.generatedToken}
                 id='tokenTitle'
                 spellCheck={false}
                 value={accessTokenLabel}
@@ -99,7 +99,7 @@ export const AccessTokensControl = observer(({ className }: { className?: string
             <Button
               appearance='accent'
               className={styles.generateTokenButton}
-              disabled={!accessTokenLabel || !!accessTokenService.generatedTokenId}
+              disabled={!accessTokenLabel || !!accessTokenService.generatedToken}
               mode='secondary'
               size='m'
               type='submit'

--- a/ui/src/services/access-token-service.ts
+++ b/ui/src/services/access-token-service.ts
@@ -19,7 +19,7 @@ export class AccessTokenService {
   private tokenToRemove = ''
   private userTokenQueries = new Map()
 
-  generatedTokenId = ''
+  generatedToken = ''
 
   constructor(@inject(CONTAINER_IDS.factoryMobxQuery) private mobxQueryFactory: MobxQueryFactory) {
     makeAutoObservable(this)
@@ -60,7 +60,7 @@ export class AccessTokenService {
       return [accessTokenLabel, ...oldData]
     })
 
-    this.generatedTokenId = ''
+    this.generatedToken = ''
   }
 
   addAccessTokenGeneratedListener(): void {
@@ -89,7 +89,8 @@ export class AccessTokenService {
     })
   }
 
-  private onAccessTokenGenerated({ tokenId }: AccessTokenGeneratedMessage): void {
-    this.generatedTokenId = tokenId
+  private onAccessTokenGenerated({ token }: AccessTokenGeneratedMessage): void {
+    this.generatedToken = token
   }
 }
+

--- a/ui/src/services/access-token-service.ts
+++ b/ui/src/services/access-token-service.ts
@@ -93,4 +93,3 @@ export class AccessTokenService {
     this.generatedToken = token
   }
 }
-

--- a/ui/src/types/access-token-generated-message.type.ts
+++ b/ui/src/types/access-token-generated-message.type.ts
@@ -1,4 +1,4 @@
 export type AccessTokenGeneratedMessage = {
   title: string
-  tokenId: string
+  token: string
 }


### PR DESCRIPTION
Now after token generation we pass jwt to user, instead of (tokenID aka legacy token)
Both types of token will be working