### PR TITLE
Improves device booking logic

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -36,7 +36,7 @@ import * as storageTemp from './storage-temp/index.js'
 import * as triproxy from './triproxy/index.js'
 import * as websocket from './websocket/index.js'
 import * as tizenDevice from './tizen-device/index.js'
-import globalLogger from '../util/logger.ts'
+import globalLogger from '../util/logger.js'
 
 yargs(hideBin(process.argv)).usage('Usage: $0 <command> [options]')
     .strict()

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -36,6 +36,7 @@ import * as storageTemp from './storage-temp/index.js'
 import * as triproxy from './triproxy/index.js'
 import * as websocket from './websocket/index.js'
 import * as tizenDevice from './tizen-device/index.js'
+import globalLogger from '../util/logger.ts'
 
 yargs(hideBin(process.argv)).usage('Usage: $0 <command> [options]')
     .strict()
@@ -76,4 +77,7 @@ yargs(hideBin(process.argv)).usage('Usage: $0 <command> [options]')
     .alias('h', 'help')
     .version()
     .alias('V', 'version')
+    .middleware([(argv) => {
+        globalLogger.unit = argv._ + ''
+    }])
     .parse()

--- a/lib/db/models/all/model.js
+++ b/lib/db/models/all/model.js
@@ -1117,6 +1117,7 @@ export const loadBookableDevicesWithFiltersLock = function(groups, abi, model, t
                     {'group.class': {$eq: apiutil.BOOKABLE}},
                     {present: {$eq: true}},
                     {ready: {$eq: true}},
+                    {status: {$eq: 3}},
                     {owner: {$eq: null}},
                     {'group.lock': {$eq: false}},
                     ...filterOptions

--- a/lib/units/api/helpers/useDevice.js
+++ b/lib/units/api/helpers/useDevice.js
@@ -41,6 +41,20 @@ const useDevice = ({user, device, channelRouter, push, sub, usage = null, log}) 
         return reject(UseDeviceError.ALREADY_IN_USE)
     }
 
+    const deviceRequirements = wireutil.toDeviceRequirements({
+        serial: {
+            value: device.serial,
+            match: 'exact'
+        }
+    })
+
+    try {
+        await runTransaction(device.channel, new wire.UngroupMessage(deviceRequirements), {sub, push, channelRouter})
+    }
+    catch (e) {
+        log?.info(e)
+    }
+
     const responseTimeout = setTimeout(function() {
         channelRouter.removeListener(wireutil.global, useDeviceMessageListener)
         return reject(UseDeviceError.FAILED_JOIN)
@@ -87,19 +101,6 @@ const useDevice = ({user, device, channelRouter, push, sub, usage = null, log}) 
 
     channelRouter.on(wireutil.global, useDeviceMessageListener)
 
-    const deviceRequirements = wireutil.toDeviceRequirements({
-        serial: {
-            value: device.serial,
-            match: 'exact'
-        }
-    })
-
-    try {
-        await runTransaction(device.channel, new wire.UngroupMessage(deviceRequirements), {sub, push, channelRouter})
-    }
-    catch (e) {
-        log?.info(e)
-    }
     await runTransaction(device.channel, new wire.GroupMessage(
         new wire.OwnerMessage(user.email, user.name, user.group)
         , timeout

--- a/lib/units/device/plugins/group.js
+++ b/lib/units/device/plugins/group.js
@@ -85,7 +85,7 @@ export default syrup.serial()
                 .then(function(group) {
                     log.important('No longer owned by "%s"', group.email)
                     log.info('Unsubscribing from group channel "%s"', group.group)
-                    dbapi.enhanceStatusChangedAt(options.serial, 0).then(() => {
+                    return dbapi.enhanceStatusChangedAt(options.serial, 0).then(() => {
                         push.send([
                             wireutil.global,
                             wireutil.envelope(new wire.LeaveGroupMessage(options.serial, group, reason))

--- a/lib/wire/transmanager.js
+++ b/lib/wire/transmanager.js
@@ -7,7 +7,8 @@ import wireutil from './util.js'
 
 export const runTransaction = (channel, message, {sub, push, channelRouter, timeout = apiutil.GRPC_WAIT_TIMEOUT}) => {
     return Sentry.startSpan({
-        name: 'wire.transaction',
+        op: 'wireTransaction',
+        name: message.$code,
         attributes: {
             message,
             channel,

--- a/lib/wire/util.js
+++ b/lib/wire/util.js
@@ -16,7 +16,7 @@ const wireutil = {
             authorizing: 'AUTHORIZING'
         }[type]]
     },
-    toDeviceRequirements: function(requirements) {
+    toDeviceRequirements: function(/** @type {{ [x: string]: {value: string, match: "semver" | "glob" | "exact"}; }} */ requirements) {
         return Object.keys(requirements).map(function(name) {
             var item = requirements[name]
             return new wire.DeviceRequirement(name, item.value, wire.RequirementType[item.match.toUpperCase()])


### PR DESCRIPTION
Updates device booking to consider device status and ensures device requirements are handled correctly during grouping/ungrouping.

Specifically:

- Adds a filter to only include devices with a status of 3 when loading bookable devices.
- Moves the ungroup device transaction before the response timeout to ensure proper device state before further actions.