### PR TITLE
Adds option to disable logs over wire

### DIFF
--- a/lib/cli/device/index.js
+++ b/lib/cli/device/index.js
@@ -189,6 +189,11 @@ export const builder = function(yargs) {
             type: 'string',
             default: '0000'
         })
+        .option('disable-logs-over-wire', {
+            describe: 'Disable sending logs over wire',
+            type: 'boolean',
+            default: false
+        })
         .option('secret', {
             describe: 'The secret to use for auth JSON Web Tokens. Anyone who ' +
                 'knows this token can freely enter the system if they want, so keep ' +
@@ -234,6 +239,7 @@ export const handler = function(argv) {
         host: argv.host,
         urlWithoutAdbPort: argv.urlWithoutAdbPort,
         deviceCode: argv.deviceCode,
-        secret: argv.secret
+        secret: argv.secret,
+        disableLogsOverWire: argv.disableLogsOverWire
     })
 }

--- a/lib/cli/ios-device/index.js
+++ b/lib/cli/ios-device/index.js
@@ -159,6 +159,11 @@ export const builder = function(yargs) {
             describe: 'Define ios device type',
             type: 'boolean'
         })
+        .option('disable-logs-over-wire', {
+            describe: 'Disable sending logs over wire',
+            type: 'boolean',
+            default: false
+        })
 }
 export const handler = function(argv) {
     return iosDevice({
@@ -192,6 +197,7 @@ export const handler = function(argv) {
         esp32Path: argv.esp32Path,
         secret: argv.secret,
         connectPort: argv.connectPort,
-        isSimulator: argv.isSimulator
+        isSimulator: argv.isSimulator,
+        disableLogsOverWire: argv.disableLogsOverWire
     })
 }

--- a/lib/cli/provider/index.js
+++ b/lib/cli/provider/index.js
@@ -212,6 +212,11 @@ export const builder = function(yargs) {
             default: process.env.SECRET || 'kute kittykat',
             demand: true
         })
+        .option('disable-logs-over-wire', {
+            describe: 'Disable sending logs over wire',
+            type: 'boolean',
+            default: false
+        })
         .epilog('Each option can be be overwritten with an environment variable ' +
         'by converting the option to uppercase, replacing dashes with ' +
         'underscores and prefixing it with `STF_PROVIDER_` (e.g. ' +
@@ -262,7 +267,8 @@ export const handler = function(argv) {
                 '--host', argv.host,
                 '--url-without-adb-port', argv.urlWithoutAdbPort,
                 '--device-code', argv.deviceCode,
-                '--secret', argv.secret
+                '--secret', argv.secret,
+                '--disable-logs-over-wire', argv.disableLogsOverWire
             ]
                 .concat(argv.connectSub.reduce(function(all, val) {
                     return all.concat(['--connect-sub', val])

--- a/lib/units/base-device/support/logger.js
+++ b/lib/units/base-device/support/logger.js
@@ -9,12 +9,18 @@ export default syrup.serial()
         // Show serial number in logs
         logger.setGlobalIdentifier(options.serial)
 
-        // Forward all logs
-        logger.on('entry', entry => {
-            push.send([
-                wireutil.global,
-                wireutil.envelope(new wire.DeviceLogMessage(options.serial, entry.timestamp / 1000, entry.priority, entry.tag, entry.pid, entry.message, entry.identifier))
-            ])
-        })
+        if (!options.disableLogsOverWire) {
+            // Forward all logs
+            logger.on('entry', entry => {
+                push.send([
+                    wireutil.global,
+                    wireutil.envelope(new wire.DeviceLogMessage(options.serial, entry.timestamp / 1000, entry.priority, entry.tag, entry.pid, entry.message, entry.identifier))
+                ])
+            })
+        }
+        else {
+            const l = logger.createLogger('device:logger')
+            l.warn('Pushing logs over wire is disabled')
+        }
         return logger
     })


### PR DESCRIPTION
Adds a new option to disable sending logs over the wire. This can be useful in situations where the logs are not needed or are causing performance issues.