### PR TITLE
Launching a device unit without a provider

### DIFF
--- a/lib/cli/device/index.js
+++ b/lib/cli/device/index.js
@@ -1,4 +1,5 @@
 import device from '../../units/device/index.js'
+import ip from 'my-local-ip'
 export const command = 'device'
 export const builder = function(yargs) {
     return yargs
@@ -92,24 +93,23 @@ export const builder = function(yargs) {
         .option('provider', {
             alias: 'n',
             describe: 'Name of the provider.',
-            type: 'string',
-            demand: true
+            type: 'string'
         })
         .option('public-ip', {
             describe: 'The IP or hostname to use in URLs.',
             type: 'string',
-            demand: true
+            default: ip()
         })
         .option('screen-frame-rate', {
             describe: 'The frame rate (frames/s) to be used for screen transport on the network. ' +
             'Float value must be > 0.0 otherwise the default behavior is kept',
             type: 'number',
-            default: process.env.SCREEN_FRAME_RATE || -1
+            default: process.env.SCREEN_FRAME_RATE || 20
         })
         .option('screen-jpeg-quality', {
             describe: 'The JPG quality to use for the screen.',
             type: 'number',
-            default: process.env.SCREEN_JPEG_QUALITY || 1 // 80
+            default: process.env.SCREEN_JPEG_QUALITY || 80
         })
         .option('screen-grabber', {
             describe: 'The tool to be used for screen capture. ' +

--- a/lib/units/device/index.js
+++ b/lib/units/device/index.js
@@ -64,6 +64,8 @@ export default (function(options) {
                 ])
 
                 await waitRegister
+                router.removeListener(wire.DeviceRegisteredMessage, listener)
+                listener = null
             }
 
             return syrup.serial()

--- a/lib/units/device/index.js
+++ b/lib/units/device/index.js
@@ -30,17 +30,44 @@ import filesystem from './plugins/filesystem.js'
 import mobileService from './plugins/mobile-service.js'
 import remotedebug from './plugins/remotedebug.js'
 import {trackModuleReadyness} from './readyness.js'
+import wireutil from '../../wire/util.js'
+import wire from '../../wire/index.js'
+import push from '../base-device/support/push.js'
+import adb from './support/adb.js'
+import router from '../base-device/support/router.js'
+
 export default (function(options) {
-    let log = logger.createLogger('device')
     return syrup.serial()
         // We want to send logs before anything else starts happening
         .dependency(logger$0)
-        .define(function(options) {
+        .dependency(push)
+        .dependency(adb)
+        .dependency(router)
+        .dependency(trackModuleReadyness('solo', solo))
+        .define(async(options, logger, push, adb, router, solo) => {
             const log = logger.createLogger('device')
             log.info('Preparing device')
+
+            if (!options.provider) {
+                let listener
+                const waitRegister = Promise.race([
+                    new Promise(resolve =>
+                        router.on(wire.DeviceRegisteredMessage, listener = (...args) => resolve(args))
+                    ),
+                    new Promise(r => setTimeout(r, 15000))
+                ])
+
+                const type = await adb.getDevice(options.serial).getState()
+                push?.send([
+                    wireutil.global,
+                    wireutil.envelope(new wire.DeviceIntroductionMessage(options.serial, wireutil.toDeviceStatus(type), new wire.ProviderMessage(solo.channel, `standalone-${options.serial}`)))
+                ])
+
+                await waitRegister
+            }
+
             return syrup.serial()
                 .dependency(trackModuleReadyness('heartbeat', heartbeat))
-                .dependency(trackModuleReadyness('solo', solo))
                 .dependency(trackModuleReadyness('stream', stream))
                 .dependency(trackModuleReadyness('capture', capture))
                 .dependency(trackModuleReadyness('service', service))
@@ -66,7 +93,7 @@ export default (function(options) {
                 .dependency(trackModuleReadyness('filesystem', filesystem))
                 .dependency(trackModuleReadyness('mobileService', mobileService))
                 .dependency(trackModuleReadyness('remotedebug', remotedebug))
-                .define(function(options, heartbeat, solo) {
+                .define(function(options, heartbeat) {
                     if (process.send) {
                         // Only if we have a parent process
                         process.send('ready')
@@ -78,10 +105,9 @@ export default (function(options) {
         })
         .consume(options)
         .catch(function(err) {
-            log.fatal('Setup had an error', err.stack)
             if (err.stack.includes('no service started')) {
                 return lifecycle.graceful(err.stack)
             }
-            lifecycle.fatal()
+            lifecycle.fatal(`Setup had an error ${err.stack}`)
         })
 })


### PR DESCRIPTION
To run a device without a provider, 
you must ***not*** specify `--provider` 
in the arguments of the `devicehub device` */* `stf device` cli command
***
```bash
devicehub device \
--serial emulator-5556 \
--screen-port 7404 \
--connect-port 7408 \
--vnc-port 5900 \
--storage-url http://localhost:7100 \
--secret qwe \
--connect-sub tcp://127.0.0.1:7114 \
--connect-push tcp://127.0.0.1:7116
```