### PR TITLE
fix error message and button on auth-ldap-page

### DIFF
--- a/ui/src/components/views/auth/auth-ldap-page.tsx
+++ b/ui/src/components/views/auth/auth-ldap-page.tsx
@@ -21,7 +21,7 @@ export const AuthLdapPage = () => {
   const [usernameError, setUsernameError] = useState('')
   const [passwordError, setPasswordError] = useState('')
   const [formError, setFormError] = useState('')
-  const { data: authData, error, mutate: auth, isSuccess } = useLdapAuth()
+  const { data: authData, error, mutate: auth, isSuccess, isPending } = useLdapAuth()
   const { data: authContact } = useGetAuthContact()
 
   const onFormSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -51,8 +51,8 @@ export const AuthLdapPage = () => {
   }, [authData])
 
   useEffect(() => {
-    if (error?.response?.data.error === 'ValidationError') {
-      for (const item of error.response.data.validationErrors) {
+    if (error?.data.error === 'ValidationError') {
+      for (const item of error.data.validationErrors) {
         if (item.param === 'username') {
           setUsernameError(item.msg)
         }
@@ -65,13 +65,13 @@ export const AuthLdapPage = () => {
       return
     }
 
-    if (error?.response?.data.error === 'InvalidCredentialsError') {
+    if (error?.data.error === 'InvalidCredentialsError') {
       setFormError('Incorrect login details')
 
       return
     }
 
-    if (error?.response?.data.error) {
+    if (error?.data.error) {
       setFormError('We do not recognize you. Please check your spelling and try again or use another login option')
     }
   }, [error])
@@ -113,7 +113,8 @@ export const AuthLdapPage = () => {
                 <Spacing size='xl' />
                 <FormItem>
                   <Button
-                    disabled={!username || !password || !!usernameError || !!passwordError || !!formError}
+                    disabled={!username || !password || !!usernameError || !!passwordError || isPending}
+                    loading={isPending}
                     size='l'
                     type='submit'
                     stretched

--- a/ui/src/lib/hooks/use-ldap-auth.hook.ts
+++ b/ui/src/lib/hooks/use-ldap-auth.hook.ts
@@ -2,12 +2,12 @@ import { useMutation } from '@tanstack/react-query'
 
 import { ldapAuth } from '@/api/auth'
 
-import type { AxiosError } from 'axios'
+import type { AxiosResponse } from 'axios'
 import type { AuthResponse, LdapAuthArgs } from '@/api/auth/types'
 import type { UseMutationResult } from '@tanstack/react-query'
 import type { AuthErrorResponse } from '@/types/auth-error-response.type'
 
-export const useLdapAuth = (): UseMutationResult<AuthResponse, AxiosError<AuthErrorResponse>, LdapAuthArgs> =>
+export const useLdapAuth = (): UseMutationResult<AuthResponse, AxiosResponse<AuthErrorResponse>, LdapAuthArgs> =>
   useMutation({
     mutationFn: (data) => ldapAuth(data),
   })


### PR DESCRIPTION
The problem was that authentication errors were not displayed, and the login button was not disabled during the execution of the request.

After fix:

Show error message after login
<img width="510" height="491" alt="Снимок экрана 2025-12-11 в 18 16 08" src="https://github.com/user-attachments/assets/7022c36a-697d-4d35-8c7c-ebebde1bd64a" />

Disable button during processing request
<img width="622" height="556" alt="Снимок экрана 2025-12-11 в 18 16 25" src="https://github.com/user-attachments/assets/78943a78-57bf-4113-b0cc-d2ef74224764" />

