### PR TITLE
fix: add missing ZeroMQ endpoints to docker-compose (macos)

### DIFF
--- a/docker-compose-macos.yaml
+++ b/docker-compose-macos.yaml
@@ -108,7 +108,14 @@ services:
         container_name: devicehub-processor
         env_file:
             - scripts/variables.env
-        command: stf processor --name processor --connect-app-dealer tcp://devicehub-triproxy-app:7160 --connect-dev-dealer tcp://devicehub-triproxy-dev:7260
+        command: >
+          stf processor --name processor
+          --connect-app-dealer tcp://devicehub-triproxy-app:7160
+          --connect-dev-dealer tcp://devicehub-triproxy-dev:7260
+          --connect-push tcp://devicehub-triproxy-app:7170
+          --connect-push-dev tcp://devicehub-triproxy-dev:7270
+          --connect-sub tcp://devicehub-triproxy-app:7150
+          --connect-sub-dev tcp://devicehub-triproxy-dev:7250
         depends_on:
             devicehub-migrate:
                 condition: service_completed_successfully
@@ -233,7 +240,12 @@ services:
         container_name: devicehub-api-groups-engine
         env_file:
             - scripts/variables.env
-        command: stf groups-engine --connect-push tcp://devicehub-triproxy-app:7170 --connect-push-dev tcp://devicehub-triproxy-dev:7270
+        command: >
+          stf groups-engine
+          --connect-push tcp://devicehub-triproxy-app:7170
+          --connect-push-dev tcp://devicehub-triproxy-dev:7270
+          --connect-sub tcp://devicehub-triproxy-app:7150
+          --connect-sub-dev tcp://devicehub-triproxy-dev:7250
         depends_on:
             devicehub-migrate:
                 condition: service_completed_successfully


### PR DESCRIPTION
Without these arguments, the `processor` and `groups-engine` services crash on startup, causing devices to be invisible in the interface.