### PR TITLE
fix open browser, execute shell command and logcat

### DIFF
--- a/docker-compose-macos.yaml
+++ b/docker-compose-macos.yaml
@@ -108,7 +108,14 @@ services:
         container_name: devicehub-processor
         env_file:
             - scripts/variables.env
-        command: stf processor --name processor --connect-app-dealer tcp://devicehub-triproxy-app:7160 --connect-dev-dealer tcp://devicehub-triproxy-dev:7260
+        command: >
+          stf processor --name processor
+          --connect-app-dealer tcp://devicehub-triproxy-app:7160
+          --connect-dev-dealer tcp://devicehub-triproxy-dev:7260
+          --connect-push tcp://devicehub-triproxy-app:7170
+          --connect-push-dev tcp://devicehub-triproxy-dev:7270
+          --connect-sub tcp://devicehub-triproxy-app:7150
+          --connect-sub-dev tcp://devicehub-triproxy-dev:7250
         depends_on:
             devicehub-migrate:
                 condition: service_completed_successfully
@@ -233,7 +240,12 @@ services:
         container_name: devicehub-api-groups-engine
         env_file:
             - scripts/variables.env
-        command: stf groups-engine --connect-push tcp://devicehub-triproxy-app:7170 --connect-push-dev tcp://devicehub-triproxy-dev:7270
+        command: >
+          stf groups-engine
+          --connect-push tcp://devicehub-triproxy-app:7170
+          --connect-push-dev tcp://devicehub-triproxy-dev:7270
+          --connect-sub tcp://devicehub-triproxy-app:7150
+          --connect-sub-dev tcp://devicehub-triproxy-dev:7250
         depends_on:
             devicehub-migrate:
                 condition: service_completed_successfully

--- a/lib/units/websocket/index.js
+++ b/lib/units/websocket/index.js
@@ -60,11 +60,32 @@ import {
     UpdateRemoteConnectUrl,
     KeyDownMessage,
     KeyUpMessage,
-    KeyPressMessage
+    KeyPressMessage,
+    ShellCommandMessage,
+    LogcatFilter,
+    LogcatStartMessage,
+    BrowserOpenMessage,
+    BrowserClearMessage
 } from '../../wire/wire.js'
 import AllModel from '../../db/models/all/index.js'
 import UserModel from '../../db/models/user/index.js'
 const request = Promise.promisifyAll(postmanRequest)
+
+function toLogcatFilters(data) {
+    const filters = Array.isArray(data?.filters) ? data.filters : data?.filters ? [data.filters] : []
+
+    return filters
+        .filter(function(filter) {
+            return filter.tag && filter.tag !== '*'
+        })
+        .map(function(filter) {
+            return LogcatFilter.create({
+                tag: filter.tag,
+                priority: filter.priority
+            })
+        })
+}
+
 export default (async function(options) {
     const log = logger.createLogger('websocket')
     const server = http.createServer()
@@ -626,7 +647,7 @@ export default (async function(options) {
                         devices.forEach(device => {
                             push.send([
                                 device.channel,
-                                wireutil.envelope(new wire.ShellCommandMessage({
+                                wireutil.pack(ShellCommandMessage, ShellCommandMessage.create({
                                     command: command,
                                     timeout: 10000
                                 }))
@@ -981,7 +1002,10 @@ export default (async function(options) {
                     joinChannel(responseChannel)
                     push.send([
                         channel,
-                        wireutil.transaction(responseChannel, new wire.ShellCommandMessage(data))
+                        wireutil.tr(responseChannel, ShellCommandMessage, ShellCommandMessage.create({
+                            command: data.command,
+                            timeout: data.timeout || 10000
+                        }))
                     ])
                 })
                 .on('shell.keepalive', function(channel, data) {
@@ -1194,7 +1218,9 @@ export default (async function(options) {
                     joinChannel(responseChannel)
                     push.send([
                         channel,
-                        wireutil.transaction(responseChannel, new wire.LogcatStartMessage(data))
+                        wireutil.tr(responseChannel, LogcatStartMessage, LogcatStartMessage.create({
+                            filters: toLogcatFilters(data)
+                        }))
                     ])
                 })
                 .on('logcat.startIos', function(channel, responseChannel, data) {
@@ -1205,7 +1231,9 @@ export default (async function(options) {
                     joinChannel(responseChannel)
                     push.send([
                         channel,
-                        wireutil.transaction(responseChannel, new wire.LogcatStartMessage(data))
+                        wireutil.tr(responseChannel, LogcatStartMessage, LogcatStartMessage.create({
+                            filters: toLogcatFilters(data)
+                        }))
                     ])
                 })
                 .on('logcat.stop', function(channel, responseChannel) {
@@ -1259,7 +1287,10 @@ export default (async function(options) {
                     joinChannel(responseChannel)
                     push.send([
                         channel,
-                        wireutil.transaction(responseChannel, new wire.BrowserOpenMessage(data))
+                        wireutil.tr(responseChannel, BrowserOpenMessage, BrowserOpenMessage.create({
+                            url: data.url,
+                            browser: data.browser || undefined
+                        }))
                     ])
                 })
                 .on('browser.openIos', function(channel, responseChannel, data) {
@@ -1270,7 +1301,10 @@ export default (async function(options) {
                     joinChannel(responseChannel)
                     push.send([
                         channel,
-                        wireutil.transaction(responseChannel, new wire.BrowserOpenMessage(data))
+                        wireutil.tr(responseChannel, BrowserOpenMessage, BrowserOpenMessage.create({
+                            url: data.url,
+                            browser: data.browser || undefined
+                        }))
                     ])
                 })
                 .on('browser.clear', function(channel, responseChannel, data) {
@@ -1281,7 +1315,9 @@ export default (async function(options) {
                     joinChannel(responseChannel)
                     push.send([
                         channel,
-                        wireutil.transaction(responseChannel, new wire.BrowserClearMessage(data))
+                        wireutil.tr(responseChannel, BrowserClearMessage, BrowserClearMessage.create({
+                            browser: data.browser || undefined
+                        }))
                     ])
                 })
                 .on('store.open', function(channel, responseChannel) {

--- a/lib/wire/util.ts
+++ b/lib/wire/util.ts
@@ -90,8 +90,12 @@ const wireutil = {
                     body: body ? JSON.stringify(body) : undefined
                 })
             },
-            progress(data: string, progress: number) {
-                if (!Number.isInteger(progress)) {
+            progress(data: string, progress = 0) {
+                if (!Number.isFinite(progress)) {
+                    log.warn('Somebody is sending non finite progress: %s', data)
+                    progress = 0
+                }
+                else if (!Number.isInteger(progress)) {
                     log.warn('Somebody is sending non integer as progress: %s', data)
                     progress = Math.round(progress)
                 }


### PR DESCRIPTION
**Fix websocket wire message construction for shell, browser, and logcat.**

- Fixed shell/browser payloads being serialized as objects, which caused [object Object] commands and URLs on providers.
- Normalized Logcat filters before creating LogcatStartMessage, including treating default tag='*' as no server-side filter.
- Maked transaction progress replies safe when no numeric progress value is provided, fixing shell output streaming crashes.

**example of a failure before:**
```
2025-12-16T13:39:22.288Z device INF/device:plugins:browser 23983 [*] Opening "http://[object Object]"
2025-12-16T13:39:58.733Z device INF/device:plugins:shell 23983 [*] Running shell command "[object Object]"
```