### PR TITLE
fix execute shell command

### DIFF
--- a/lib/wire/util.ts
+++ b/lib/wire/util.ts
@@ -90,8 +90,12 @@ const wireutil = {
                     body: body ? JSON.stringify(body) : undefined
                 })
             },
-            progress(data: string, progress: number) {
-                if (!Number.isInteger(progress)) {
+            progress(data: string, progress = 0) {
+                if (!Number.isFinite(progress)) {
+                    log.warn('Somebody is sending non finite progress: %s', data)
+                    progress = 0
+                }
+                else if (!Number.isInteger(progress)) {
                     log.warn('Somebody is sending non integer as progress: %s', data)
                     progress = Math.round(progress)
                 }


### PR DESCRIPTION
**failures on provider before:**

```
2026-04-13T14:34:42.666Z device INF/device:plugins:shell 17214 [*] Running shell command "pwd"
2026-04-13T14:34:42.680Z device WRN/wireutil 17214 [*] Somebody is sending non integer as progress: /
2026-04-13T14:34:42.683Z device ERR/console 17214 [*] /Users/service_user/devicehub/devicehub/node_modules/assert.js:32
        throw new Error('invalid uint 32: ' + arg);
              ^
2026-04-13T14:34:42.684Z device ERR/console 17214 [*] Error: invalid uint 32: NaN
    at Object.assertUInt32 (/Users/service_user/devicehub/devicehub/node_modules/assert.js:32:15)
```