### PR TITLE
Skip APK manifest lookup for iOS installs

### DIFF
--- a/ui/src/services/application-installation/application-installation-service.ts
+++ b/ui/src/services/application-installation/application-installation-service.ts
@@ -44,7 +44,7 @@ export class ApplicationInstallationService {
   ) {
     makeAutoObservable(this)
 
-    this.manifestQuery = mobxQueryFactory(() => ({ ...queries.s.apk(this.href), enabled: !!this.href }))
+    this.manifestQuery = mobxQueryFactory(() => ({ ...queries.s.apk(this.href), enabled: !!this.href && this.isAndroid }))
     this.uploadFileMutate = mobxMutationFactory<UploadFileResponse, ErrorResponse, UploadFileArgs>({
       mutationFn: (data): Promise<UploadFileResponse> => uploadFile(data),
     })


### PR DESCRIPTION
## Summary
- Only enable APK manifest lookup for Android installs
- Avoid requesting `/manifest` for iOS `.ipa` uploads stored as `/s/blob/...`

## Problem
The application install UI reused the Android APK manifest lookup for every uploaded file once an `href` existed. This works for Android APK uploads because manifests are exposed under `/s/apk/:id/:name/manifest`, but iOS IPA uploads are stored as generic blobs under `/s/blob/:id/:name` and do not have a manifest endpoint.

This caused the UI to issue a failing request during iOS installs, for example:

```text
GET https://devicehub.putmyhexon.ru/s/blob/e0aff872-60ae-4e8a-bbe5-56af5cf22a44/66a009ad13b86c279b1ecc841f32f35e/manifest 404 (Not Found)
```

## Fix
Gate the manifest query with `this.isAndroid`, so the query is enabled only when installing Android applications. iOS installs continue to pass the uploaded blob href directly to the device install flow.

## Testing
- `npm run type-checking` in `ui` currently fails on pre-existing errors unrelated to this change (`exponential-backoff` module resolution and nullable promise typing in socket/device-screen code).
- Verified in a kuber test image that the production Docker build completes with this change.
