### PR TITLE
Handle iOS app launch failures after install

### DIFF
--- a/lib/units/ios-device/plugins/install.js
+++ b/lib/units/ios-device/plugins/install.js
@@ -70,14 +70,22 @@ export default syrup.serial()
             promiseutil.periodicNotify(installApp(options.serial, path), 250)
                 .progressed(() => {
                     guesstimate = Math.min(95, guesstimate + 1.5 * (95 - guesstimate) / 35)
-                    sendProgress('installing_app', guesstimate)
+                    sendProgress('installing_app', Math.round(guesstimate))
                 })
                 .then((result) => {
                     push.send([channel, reply.okay('INSTALL_SUCCEEDED')])
                     if (message.launch) {
-                        const bundleId = result.match(/.[\w.-]+[\w-]/)
+                        const bundleId = String(result).match(/Installed:?\s+([\w.-]+)/i)?.[1]
+                        if (!bundleId) {
+                            log.warn('Unable to detect bundle id from idb install output: %s', result)
+                            return
+                        }
+
                         sendProgress('launching_app', 100)
                         launchApp(options.serial, bundleId)
+                            .catch((err) => {
+                                log.warn('Application launch after install failed: %s', err.message)
+                            })
                     }
                 })
                 .catch((err) => {


### PR DESCRIPTION
## Summary
- Parse the bundle id from `idb install` output before launching an iOS app
- Avoid unhandled promise rejections when the best-effort launch fails
- Send integer install progress values

## Problem
After an iOS IPA was installed successfully, the install plugin attempted to auto-launch the app. The bundle id was parsed with a broad regular expression that could match the status word from `idb install` output instead of the actual bundle id.

For example, with install output like:

```text
Installed: com.testing.app A13F6EBD-88D6-3254-8678-B5B61FD31120
```

the old parser could try to launch `Installed` instead of `com.testing.app`, leading to an error like:

```text
Unhandled rejection Error: Command failed: idb launch Installed --udid=00008110-001454941A46801E
```

The same flow also sent fractional progress values, producing noisy warnings such as:

```text
Somebody is sending non integer as progress: installing_app
```

## Fix
Parse the bundle id explicitly from `Installed: <bundleId>` / `Installed <bundleId>` output, skip the launch if the bundle id cannot be detected, and catch launch failures so a failed post-install launch does not become an unhandled rejection. Progress updates are rounded before being sent.

## Testing
- `npm run build`
